### PR TITLE
test(validator): cover leading-zero RUT equivalence

### DIFF
--- a/spec/validates_identity/cl_rut/validator_spec.rb
+++ b/spec/validates_identity/cl_rut/validator_spec.rb
@@ -51,6 +51,30 @@ RSpec.describe ValidatesIdentity::ClRut::Validator do
     expect(described_class.new('8.549.092-3')).to be_valid
   end
 
+  it 'accepts 89134536' do
+    expect(described_class.new('89134536')).to be_valid
+  end
+
+  it 'accepts 8913453-6' do
+    expect(described_class.new('8913453-6')).to be_valid
+  end
+
+  it 'accepts 8.913.453-6' do
+    expect(described_class.new('8.913.453-6')).to be_valid
+  end
+
+  it 'accepts 089134536' do
+    expect(described_class.new('089134536')).to be_valid
+  end
+
+  it 'accepts 08913453-6' do
+    expect(described_class.new('08913453-6')).to be_valid
+  end
+
+  it 'accepts 08.913.453-6' do
+    expect(described_class.new('08.913.453-6')).to be_valid
+  end
+
   it 'rejects 8549092-1' do
     expect(described_class.new('8549092-1')).not_to be_valid
   end


### PR DESCRIPTION
## Summary

- Locks in the equivalence between 7-digit RUTs and their leading-zero 8-digit counterparts (e.g., `8913453-6` ≡ `08913453-6`), which both validate to the same verifier digit because the leading zero contributes `0` to the multiplier sum.
- Adds spec coverage for six variations of the RUT reported by a downstream integration (`8913453-6`): bare, hyphenated and formatted, with and without the leading zero.
- No behavior change. The current regex already supports both forms; this PR exists to protect against regression. No version bump, no changelog entry.

## Test plan

- [x] `bundle exec rspec` — 43 examples, 0 failures